### PR TITLE
Refactor ChordEditor to use props instead of state

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,14 +3,14 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "chordsheetjs": "^0.3.1",
-    "react": "^15.5.4",
-    "react-dom": "^15.5.4"
+    "chordsheetjs": "^1.0.4",
+    "react": "^15.6.1",
+    "react-dom": "^15.6.1"
   },
   "devDependencies": {
     "enzyme": "^2.8.2",
-    "react-addons-test-utils": "^15.5.1",
-    "react-scripts": "1.0.5"
+    "react-scripts": "^1.0.7",
+    "react-test-renderer": "^15.6.1"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/src/App.js
+++ b/src/App.js
@@ -4,12 +4,24 @@ import Footer from './components/Footer';
 import ChordEditor from './components/ChordEditor';
 
 class App extends Component {
+  constructor() {
+    super();
+    this.updateSong = this.updateSong.bind(this);
+    this.state = {
+      song: { chordpro: "Type lyrics here." }
+    };
+  }
+
+  updateSong(song) {
+    this.setState({song: song});
+  }
+
   render() {
     return (
       <div className="wrapper">
         <Header />
         <div className="workspace">
-          <ChordEditor />
+          <ChordEditor song={this.state.song} updateSong={this.updateSong}/>
         </div>
         <Footer />
       </div>

--- a/src/components/ChordEditor.js
+++ b/src/components/ChordEditor.js
@@ -5,17 +5,20 @@ class ChordEditor extends Component {
   constructor(props) {
     super(props);
     this.handleChange = this.handleChange.bind(this);
-    this.state = { value: 'Type some lyrics here' };
   }
 
-  handleChange(e) {
-    this.setState({ value: e.target.value });
+  handleChange(event) {
+    const chordpro = event.target.value;
+
+    this.props.updateSong({
+      chordpro: chordpro
+    });
   }
 
   getChordMarkup() {
-    var formatter = new ChordSheetJS.HtmlFormatter(),
-      parser = new ChordSheetJS.ChordProParser(),
-      song = parser.parse(this.state.value);
+    const formatter = new ChordSheetJS.HtmlFormatter();
+    const parser = new ChordSheetJS.ChordProParser();
+    const song = parser.parse(this.props.song.chordpro);
 
     return { __html: formatter.format(song) };
   }
@@ -28,7 +31,7 @@ class ChordEditor extends Component {
           <textarea
             style={{width: "100%", height: "100%"}}
             onChange={this.handleChange}
-            defaultValue={this.state.value}/>
+            value={this.props.song.chordpro}/>
         </div>
         <div className="panel">
           <h3>Output</h3>

--- a/src/components/ChordEditor.test.js
+++ b/src/components/ChordEditor.test.js
@@ -4,33 +4,17 @@ import ChordEditor from './ChordEditor';
 
 describe('<ChordEditor />', () => {
   it('renders an editor area', () => {
-    const editor = shallow(<ChordEditor />);
+    const editor = shallow(<ChordEditor song={{chordpro: ""}}/>);
     expect(editor.find('textarea').length).toEqual(1);
   });
 
   it('renders an output area', () => {
-    const editor = shallow(<ChordEditor />);
+    const editor = shallow(<ChordEditor song={{chordpro: ""}}/>);
     expect(editor.find('div.chord-output').length).toEqual(1);
   });
 
   it('renders the chord chart output', () => {
-    const editor = shallow(<ChordEditor />);
-    const expectedOutput =
-      '<table>' +
-      '<tr>' +
-      '<td class="chord"></td>' +
-      '</tr>' +
-      '<tr>' +
-      '<td class="lyrics">Type some lyrics here&nbsp;</td>' +
-      '</tr>' +
-      '</table>';
-
-    const realOutput = editor.find('div.chord-output').html();
-    expect(realOutput.indexOf(expectedOutput) > -1).toEqual(true);
-  });
-
-  it('renders the chord chart output', () => {
-    const editor = shallow(<ChordEditor />);
+    const editor = shallow(<ChordEditor song={{chordpro: "[B]New [Am]Lyrics"}} />);
     const expectedOutput =
       '<table>' +
       '<tr>' +
@@ -43,9 +27,20 @@ describe('<ChordEditor />', () => {
       '</tr>' +
       '</table>';
 
-    editor.setState({ value: "[B]New [Am]Lyrics" });
-
     const realOutput = editor.find('div.chord-output').html();
     expect(realOutput.indexOf(expectedOutput) > -1).toEqual(true);
+  });
+
+  it('calls updateSong when the textarea changes', () => {
+    var theSong;
+    const update = (song) => {
+      theSong = song;
+    };
+
+    const editor = shallow(<ChordEditor song={{chordpro: "[B]New [Am]Lyrics"}} updateSong={update} />);
+
+    editor.find('textarea').simulate("change", { target: { value: "[B]New [Am]Lyrics "}});
+
+    expect(theSong).toEqual({ chordpro: "[B]New [Am]Lyrics "});
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1260,9 +1260,9 @@ chokidar@^1.4.3, chokidar@^1.6.0:
   optionalDependencies:
     fsevents "^1.0.0"
 
-chordsheetjs@^0.3.1:
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/chordsheetjs/-/chordsheetjs-0.3.2.tgz#c9435b1cb50a3b05d54f731cbb780a0b957af197"
+chordsheetjs@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/chordsheetjs/-/chordsheetjs-1.0.4.tgz#fb069e08f17c6643de5a06065a1992e316f1347b"
 
 ci-info@^1.0.0:
   version "1.0.0"
@@ -2084,7 +2084,7 @@ escope@^3.6.0:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
-eslint-config-react-app@^1.0.3:
+eslint-config-react-app@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/eslint-config-react-app/-/eslint-config-react-app-1.0.4.tgz#c0178f535a922236c53daafea4f397203db7d9af"
 
@@ -2135,9 +2135,9 @@ eslint-plugin-import@2.2.0:
     minimatch "^3.0.3"
     pkg-up "^1.0.0"
 
-eslint-plugin-jsx-a11y@5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-5.0.1.tgz#48e678891fec9fe1e53ef53adc2f7d05fee6640c"
+eslint-plugin-jsx-a11y@5.0.3:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-5.0.3.tgz#4a939f76ec125010528823331bf948cc573380b6"
   dependencies:
     aria-query "^0.5.0"
     array-includes "^3.0.3"
@@ -2388,7 +2388,7 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "^2.0.0"
 
-fbjs@^0.8.4, fbjs@^0.8.9:
+fbjs@^0.8.9:
   version "0.8.12"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.12.tgz#10b5d92f76d45575fd63a217d4ea02bea2f8ed04"
   dependencies:
@@ -4910,35 +4910,6 @@ rc@^1.0.1, rc@^1.1.6, rc@^1.1.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-addons-test-utils@^15.5.1:
-  version "15.5.1"
-  resolved "https://registry.yarnpkg.com/react-addons-test-utils/-/react-addons-test-utils-15.5.1.tgz#e0d258cda2a122ad0dff69f838260d0c3958f5f7"
-  dependencies:
-    fbjs "^0.8.4"
-    object-assign "^4.1.0"
-
-react-dev-utils@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/react-dev-utils/-/react-dev-utils-2.0.1.tgz#5843504d89f038f046258a871fc26071775fc065"
-  dependencies:
-    "@timer/detect-port" "1.1.3"
-    address "1.0.1"
-    anser "1.3.0"
-    babel-code-frame "6.22.0"
-    chalk "1.1.3"
-    cross-spawn "4.0.2"
-    escape-string-regexp "1.0.5"
-    filesize "3.3.0"
-    gzip-size "3.0.0"
-    html-entities "1.2.1"
-    inquirer "3.0.6"
-    opn "5.0.0"
-    recursive-readdir "2.2.1"
-    shell-quote "1.6.1"
-    sockjs-client "1.1.4"
-    strip-ansi "3.0.1"
-    text-table "0.2.0"
-
 react-dev-utils@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/react-dev-utils/-/react-dev-utils-3.0.0.tgz#3677f37718ba0cae892ba9c01fe54d1622e6ef7c"
@@ -4961,7 +4932,7 @@ react-dev-utils@^3.0.0:
     strip-ansi "3.0.1"
     text-table "0.2.0"
 
-react-dom@^15.5.4:
+react-dom@^15.6.1:
   version "15.6.1"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-15.6.1.tgz#2cb0ed4191038e53c209eb3a79a23e2a4cf99470"
   dependencies:
@@ -4970,7 +4941,7 @@ react-dom@^15.5.4:
     object-assign "^4.1.0"
     prop-types "^15.5.10"
 
-react-error-overlay@^1.0.5:
+react-error-overlay@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-1.0.7.tgz#8712fe40cfc194ce992a4136c091c03bfada9148"
   dependencies:
@@ -4981,9 +4952,9 @@ react-error-overlay@^1.0.5:
     settle-promise "1.0.0"
     source-map "0.5.6"
 
-react-scripts@1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/react-scripts/-/react-scripts-1.0.5.tgz#36e7302f4be16c6511f3b50a7a7bad4b2da5cb02"
+react-scripts@^1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/react-scripts/-/react-scripts-1.0.7.tgz#fe1436dda03bb45465c76d097cfea4f32eb7cbbb"
   dependencies:
     autoprefixer "7.1.0"
     babel-core "6.24.1"
@@ -4997,11 +4968,11 @@ react-scripts@1.0.5:
     css-loader "0.28.1"
     dotenv "4.0.0"
     eslint "3.19.0"
-    eslint-config-react-app "^1.0.3"
+    eslint-config-react-app "^1.0.4"
     eslint-loader "1.7.1"
     eslint-plugin-flowtype "2.33.0"
     eslint-plugin-import "2.2.0"
-    eslint-plugin-jsx-a11y "5.0.1"
+    eslint-plugin-jsx-a11y "5.0.3"
     eslint-plugin-react "7.0.1"
     extract-text-webpack-plugin "2.1.0"
     file-loader "0.11.1"
@@ -5012,19 +4983,26 @@ react-scripts@1.0.5:
     postcss-flexbugs-fixes "3.0.0"
     postcss-loader "2.0.5"
     promise "7.1.1"
-    react-dev-utils "^2.0.0"
-    react-error-overlay "^1.0.5"
+    react-dev-utils "^3.0.0"
+    react-error-overlay "^1.0.7"
     style-loader "0.17.0"
     sw-precache-webpack-plugin "0.9.1"
     url-loader "0.5.8"
-    webpack "2.5.1"
+    webpack "2.6.1"
     webpack-dev-server "2.4.5"
     webpack-manifest-plugin "1.1.0"
     whatwg-fetch "2.0.3"
   optionalDependencies:
     fsevents "1.0.17"
 
-react@^15.5.4:
+react-test-renderer@^15.6.1:
+  version "15.6.1"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-15.6.1.tgz#026f4a5bb5552661fd2cc4bbcd0d4bc8a35ebf7e"
+  dependencies:
+    fbjs "^0.8.9"
+    object-assign "^4.1.0"
+
+react@^15.6.1:
   version "15.6.1"
   resolved "https://registry.yarnpkg.com/react/-/react-15.6.1.tgz#baa8434ec6780bde997cdc380b79cd33b96393df"
   dependencies:
@@ -5338,13 +5316,13 @@ rx@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/rx/-/rx-4.1.0.tgz#a5f13ff79ef3b740fe30aa803fb09f98805d4782"
 
-safe-buffer@^5.0.1, safe-buffer@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.0.tgz#fe4c8460397f9eaaaa58e73be46273408a45e223"
-
-safe-buffer@~5.0.1:
+safe-buffer@^5.0.1, safe-buffer@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.0.1.tgz#d263ca54696cd8a306b5ca6551e92de57918fbe7"
+
+safe-buffer@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.0.tgz#fe4c8460397f9eaaaa58e73be46273408a45e223"
 
 sane@~1.6.0:
   version "1.6.0"
@@ -5916,7 +5894,7 @@ uglify-js@3.0.x:
     commander "~2.9.0"
     source-map "~0.5.1"
 
-uglify-js@^2.6, uglify-js@^2.8.5:
+uglify-js@^2.6, uglify-js@^2.8.27, uglify-js@^2.8.5:
   version "2.8.28"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.8.28.tgz#e335032df9bb20dcb918f164589d5af47f38834a"
   dependencies:
@@ -6161,9 +6139,9 @@ webpack-sources@^0.2.3:
     source-list-map "^1.1.1"
     source-map "~0.5.3"
 
-webpack@2.5.1:
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-2.5.1.tgz#61742f0cf8af555b87460a9cd8bba2f1e3ee2fce"
+webpack@2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-2.6.1.tgz#2e0457f0abb1ac5df3ab106c69c672f236785f07"
   dependencies:
     acorn "^5.0.0"
     acorn-dynamic-import "^2.0.0"
@@ -6182,7 +6160,7 @@ webpack@2.5.1:
     source-map "^0.5.3"
     supports-color "^3.1.0"
     tapable "~0.2.5"
-    uglify-js "^2.8.5"
+    uglify-js "^2.8.27"
     watchpack "^1.3.1"
     webpack-sources "^0.2.3"
     yargs "^6.0.0"


### PR DESCRIPTION
This commit makes the ChordEditor more useful by allowing the contents
being edited to be injected as props and we're now holding the state of
the song at the App level. We've also upgraded our dependencies and
fixed the issues that we were seeing when running our tests.