### PR TITLE
Change breadcrumbs to use pushstate via Link

### DIFF
--- a/src/components/ChordEditor.js
+++ b/src/components/ChordEditor.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { Breadcrumb } from '@blueprintjs/core';
+import { Link } from 'react-router-dom';
 import ChordSheetJS from 'chordsheetjs';
 
 class ChordEditor extends Component {
@@ -29,8 +29,8 @@ class ChordEditor extends Component {
     return (
       <div>
         <ul className="pt-breadcrumbs">
-          <li><Breadcrumb href="/songs" text="Songs" /></li>
-          <li><Breadcrumb href="#" text={song.title} /></li>
+          <li><Link to="/songs" className="pt-breadcrumb">Songs</Link></li>
+          <li><Link to="#" className="pt-breadcrumb">{song.title}</Link></li>
         </ul>
         <h2 style={{margin: "0.5em 0"}}>{song.title}</h2>
         <div className="chord-editor">


### PR DESCRIPTION
If you tried to navigate from the ChordEditor back to the songs list
by click on a breadcrumb, it would cause an actual redirect instead of
using pushstate. This would cause the application to need to load again and
would additionally cause a 404 if the subpath redirection isn't present on
your web server.

closes #9 